### PR TITLE
Zmiana cooldownu i minimalnej ilości znaków.

### DIFF
--- a/modules/levelsGain.js
+++ b/modules/levelsGain.js
@@ -18,14 +18,14 @@ module.exports = async (parameters) => {
         if(membersOnline.length < 10) return;
 
         const messageContent = message.content.trim();
-        if(messageContent.length <= 5) return;
+        if(messageContent.length < 5) return;
         if(messageContent.startsWith('!')) return;
 
         gainDisablement[message.author.id] = true;
 
         setTimeout(() => {
             gainDisablement[message.author.id] = false;
-        }, 240 / messageContent.length);
+        }, (240 / messageContent.length) * 1000);
 
         const gainedPoints = Random.integer(1, 3)(Random.engines.nativeMath);
 

--- a/modules/levelsGain.js
+++ b/modules/levelsGain.js
@@ -18,14 +18,14 @@ module.exports = async (parameters) => {
         if(membersOnline.length < 10) return;
 
         const messageContent = message.content.trim();
-        if(messageContent.length < 15) return;
+        if(messageContent.length <= 5) return;
         if(messageContent.startsWith('!')) return;
 
         gainDisablement[message.author.id] = true;
 
         setTimeout(() => {
             gainDisablement[message.author.id] = false;
-        }, 15 * 1000);
+        }, 240 / messageContent.length);
 
         const gainedPoints = Random.integer(1, 3)(Random.engines.nativeMath);
 


### PR DESCRIPTION
Zmiana sposobu obliczania cooldownu na `240 / message.content.trim().length`.
Zmiana minimalnej ilości znaków w wiadomości wymaganej, aby zostały za nią przyznane punkty na 5.

[https://github.com/fCommunity/fEntertainment/issues/2](Propozycja zmian) zawiera dodanie `trim()`, lecz zostało już ono wcześniej wdrożone.